### PR TITLE
Ensure query.enabled is set to true in server.properties

### DIFF
--- a/java/entrypoint.sh
+++ b/java/entrypoint.sh
@@ -158,6 +158,13 @@ if [ -f "server.properties" ]; then
 		echo "server-port=${SERVER_PORT}" >> server.properties
 	fi
 
+	# set query.enabled to true
+	if grep -q "query.enabled=" server.properties; then
+		sed -i "s/query.enabled=.*/query.enabled=true/" server.properties
+	else
+		echo "query.enabled=true" >> server.properties
+	fi
+
 	# set query.port to SERVER_PORT
 	if grep -q "query.port=" server.properties; then
 		sed -i "s/query.port=.*/query.port=${SERVER_PORT}/" server.properties


### PR DESCRIPTION
Adds logic to entrypoint.sh to set 'query.enabled=true' in server.properties, updating the value if it exists or appending it if not. This ensures the query feature is always enabled when starting the server.